### PR TITLE
Adding support for updating the ftp password

### DIFF
--- a/.env.docker.sample
+++ b/.env.docker.sample
@@ -9,3 +9,9 @@ oc_ftpHost=<hostname>
 oc_ftpRemDir=<mainframe_dir>
 oc_ftpHostDir=/records
 oc_ftpParallel=8
+# set this to true if you are trying to update to a new password
+# and make sure you set oc_ftpPass=oldpassword/newpassword/newpassword
+oc_ftpUpdatePassword=false
+# set this to true if you want to immediately start a transfer after the password is updated.
+# false if you want to skip the transfer and just exit after updating password.
+oc_ftpUpdatePassTransfer=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ ENV oc_ftpHost=""
 ENV oc_ftpRemDir=""
 ENV oc_ftpHostDir=""
 ENV oc_ftpParallel=""
-
+ENV oc_ftpUpdatePassword=""
+ENV oc_ftpUpdatePassTransfer=""
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Container is built using an openconnect container as its base then adds lftp and
 
 All variables should be set in a `.env.docker` file an example of this file is provided as `.env.docker.sample` simply.
 
+**NOTE**: Take note of the comments in .env.docker to see how to reset the FTP password that is required every 60 days. Information is in 1password about this.
+
 ```bash
 # .env.docker is default ignored in project.
 cp -p .env.docker.sample .env.docker


### PR DESCRIPTION
* Added function to update the ftp password if a certain environment variable is set.
* Used the -u argument to set the ftp username and password due to the special characters in the username such as the slash were causing issues attempting to place in the URL string.
* Allow for starting the transfer with the new password immediately after setting the password. Have not tested this yet since I just changed the password but did test with this set to false and the password was updated. Pushing the container up now anyway.
* Output the ftp password change file after complete just for debugging purposes all it does is cd to the directory and prints the directory to verify that the connection was succesful after changing the password.
* Updated the Dockerfile to include the new env variables and the sample as well with comments to detail how to do it.
* Updated readme to notify user to check comments as well.