### PR TITLE
Updating keyserver adding buildx instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,9 @@ RUN set -ex \
     && curl http://git.infradead.org/users/dwmw2/vpnc-scripts.git/blob_plain/HEAD:/vpnc-script -o /etc/vpnc/vpnc-script \
     && chmod 750 /etc/vpnc/vpnc-script \
     ## 1.3 create build dir, download, verify and decompress OC package to build dir
-    && gpg --keyserver pgp.mit.edu --recv-key 0xbe07d9fd54809ab2c4b0ff5f63762cda67e2f359 \
+    && mkdir ~/.gnupg \
+    && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && chmod 0600 ~/.gnupg \
+    && gpg --keyserver keyserver.ubuntu.com --recv-key 0xbe07d9fd54809ab2c4b0ff5f63762cda67e2f359 \
     && mkdir -p /tmp/build/openconnect \
     && curl -SL "ftp://ftp.infradead.org/pub/openconnect/openconnect-$OC_VERSION.tar.gz" -o /tmp/openconnect.tar.gz \
     && curl -SL "ftp://ftp.infradead.org/pub/openconnect/openconnect-$OC_VERSION.tar.gz.asc" -o /tmp/openconnect.tar.gz.asc \

--- a/README.md
+++ b/README.md
@@ -25,8 +25,21 @@ bin/getrecords -d -s 132414
 
 To build the container locally instead of allowing it to pull from [sdunixgeek/attocvpn](https://hub.docker.com/repository/docker/sdunixgeek/attocvpn) on docker hub do the following:
 
+Build for local machine
+
 ```bash
 docker build -f Dockerfile -t  sdunixgeek/attocvpn .
+```
+
+Buildx for multi-arch
+
+```bash
+# Create buildx instance and use
+docker buildx create --name attocvpn --use
+# Create build and push for arm64 and amd64 ti sdunixgeek
+docker buildx build --platform linux/arm64,linux/amd64 -t sdunixgeek/attocvpn:latest . --push
+# Remove buildx instance once done
+docker buildx rm attocvpn
 ```
 
 ## Example Output


### PR DESCRIPTION
* pgp.mit.edu was failing in buildx when building likely some networking issue while running in vm.
* Updating to use keyserver.ubuntu.com addressed this issue. Created a dirmngr.conf and disabled ipv6 as well.
* Adding buildx instructions for building image and pushing after update.